### PR TITLE
Fix dots being interpreted as arguments

### DIFF
--- a/argparser
+++ b/argparser
@@ -492,12 +492,12 @@ function argparser()
 
     function _argparser_is_optional_argment()
     {
-        ((${#1} > 1)) && [[ $Argparser_prefix_chars =~ ${1:0:1} ]]
+        ((${#1} > 1)) && [[ $Argparser_prefix_chars =~ "${1:0:1}" ]]
     }
 
     function _argparser_is_positional_argment()
     {
-        [[ ! $Argparser_prefix_chars =~ ${1:0:1} ]]
+        [[ ! $Argparser_prefix_chars =~ "${1:0:1}" ]]
     }
 
     function _argparser_is_long_optional_argument()

--- a/test/test-argparser.sh
+++ b/test/test-argparser.sh
@@ -491,6 +491,23 @@ function test_argparser_parse9()
     fi
 }
 
+function test_argparser_parse10()
+{
+    argparser
+    printf '%s: %s: ' "$FUNCNAME" 'Dots should not cause argument errors'
+
+    argparser_add_arg command
+
+    arg=(.mycommand)
+    e_command=(.mycommand)
+    argparser_parse "${arg[@]}"
+    if is_the_same_arr "${e_command[@]}" -- "${command[@]}"; then
+        echo ok
+    else
+        echo -e "\033[31mfail\033[0m"
+    fi
+}
+
 function test_argparser_help()
 {
     printf '%s: %s: ' "$FUNCNAME" 'argparser_help should print the right help doc'


### PR DESCRIPTION
Before, if you passed `./myscript .xyz`, argparser thought it was a short argument you were trying to pass. This is because the argument wasn't surrounded by quotes, so it was doing a regex match.