### PR TITLE
Avoid an error when there are more than two single-letter files in the current directory

### DIFF
--- a/argparser
+++ b/argparser
@@ -124,7 +124,7 @@ function argparser()
 	{
 		local prog=$1
 		local message=$2
-		local error_type=$(tr [A-Z] [a-z] <<< "${3:-error}")
+		local error_type=$(tr '[A-Z]' '[a-z]' <<< "${3:-error}")
 		local no_exit=$4
 		printf "$prog: $error_type: "'%s\n' "$message" >&2
 		[[ $no_exit ]] || exit 1


### PR DESCRIPTION
e.g.:

```
ryan@DevPC-LX ~/langtest/argparser $ rootbox box.run
usage: rootbox box.run [-h] <name> [<bind> ...] [-x] [-c command] [-u user] [-D] [-L] [-C colors]
rootbox box.run: error: argument <name> is missing.
ryan@DevPC-LX ~/langtest/argparser $ touch x y z
ryan@DevPC-LX ~/langtest/argparser $ rootbox box.run
tr: extra operand ‘z’
Try 'tr --help' for more information.
rootbox box.run: : argument <name> is missing.
usage: rootbox box.run [-h] <name> [<bind> ...] [-x] [-c command] [-u user] [-D] [-L] [-C colors]
ryan@DevPC-LX ~/langtest/argparser $ 
```